### PR TITLE
Fix code

### DIFF
--- a/pythonfuzz/__init__.py
+++ b/pythonfuzz/__init__.py
@@ -1,0 +1,1 @@
+from .fuzzer import Fuzzer

--- a/pythonfuzz/corpus.py
+++ b/pythonfuzz/corpus.py
@@ -1,16 +1,9 @@
 import os
-import math
 import random
 import struct
 import hashlib
 
 from . import dictionnary
-
-try:
-    from random import _randbelow
-except ImportError:
-    from random import _inst
-    _randbelow = _inst._randbelow
 
 INTERESTING8 = [-128, -1, 0, 1, 16, 32, 64, 100, 127]
 INTERESTING16 = [0, 128, 255, 256, 512, 1000, 1024, 4096, 32767, 65535]
@@ -51,7 +44,7 @@ class Corpus(object):
     def _rand(n):
         if n < 2:
             return 0
-        return _randbelow(n)
+        return random.randrange(n)  # = choice(range(n)) = randbelow(n)
 
     # Exp2 generates n with probability 1/2^(n+1).
     @staticmethod

--- a/pythonfuzz/fuzzer.py
+++ b/pythonfuzz/fuzzer.py
@@ -74,7 +74,7 @@ class Fuzzer(object):
         rss = (psutil.Process(self._p.pid).memory_info().rss + psutil.Process(os.getpid()).memory_info().rss) / 1024 / 1024
 
         endTime = time.time()
-        execs_per_second = int(self._executions_in_sample / (endTime - self._last_sample_time))
+        execs_per_second = int(self._executions_in_sample / (endTime - self._last_sample_time or 1e-9))
         self._last_sample_time = time.time()
         self._executions_in_sample = 0
         logging.info('#{} {}     cov: {} corp: {} exec/s: {} rss: {} MB'.format(

--- a/pythonfuzz/fuzzer.py
+++ b/pythonfuzz/fuzzer.py
@@ -1,26 +1,20 @@
 import os
-import sys
 import time
 import sys
 import psutil
 import hashlib
 import logging
-import functools
 import multiprocessing as mp
-mp.set_start_method('fork')
 
 from pythonfuzz import corpus, tracer
+
+if sys.platform != 'win32':
+    mp.set_start_method('fork')
 
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 logging.getLogger().setLevel(logging.DEBUG)
 
-SAMPLING_WINDOW = 5 # IN SECONDS
-
-try:
-    lru_cache = functools.lru_cache
-except:
-    import functools32
-    lru_cache = functools32.lru_cache
+SAMPLING_WINDOW = 5  # IN SECONDS
 
 
 def worker(target, child_conn, close_fd_mask):

--- a/pythonfuzz/fuzzer.py
+++ b/pythonfuzz/fuzzer.py
@@ -65,7 +65,7 @@ class Fuzzer(object):
         self._corpus = corpus.Corpus(self._dirs, max_input_size, dict_path)
         self._total_executions = 0
         self._executions_in_sample = 0
-        self._last_sample_time = time.time()
+        self._last_sample_time = time.perf_counter()
         self._total_coverage = 0
         self._p = None
         self.runs = runs
@@ -73,9 +73,9 @@ class Fuzzer(object):
     def log_stats(self, log_type):
         rss = (psutil.Process(self._p.pid).memory_info().rss + psutil.Process(os.getpid()).memory_info().rss) / 1024 / 1024
 
-        endTime = time.time()
+        endTime = time.perf_counter()
         execs_per_second = int(self._executions_in_sample / (endTime - self._last_sample_time or 1e-9))
-        self._last_sample_time = time.time()
+        self._last_sample_time = time.perf_counter()
         self._executions_in_sample = 0
         logging.info('#{} {}     cov: {} corp: {} exec/s: {} rss: {} MB'.format(
             self._total_executions, log_type, self._total_coverage, self._corpus.length, execs_per_second, rss))
@@ -137,7 +137,7 @@ class Fuzzer(object):
                 self._total_coverage = total_coverage
                 self._corpus.put(buf)
             else:
-                if (time.time() - self._last_sample_time) > SAMPLING_WINDOW:
+                if (time.perf_counter() - self._last_sample_time) > SAMPLING_WINDOW:
                     rss = self.log_stats('PULSE')
 
             if rss > self._rss_limit_mb:

--- a/pythonfuzz/main.py
+++ b/pythonfuzz/main.py
@@ -27,7 +27,3 @@ class PythonFuzz(object):
                           args.rss_limit_mb, args.timeout, args.regression, args.max_input_size,
                           args.close_fd_mask, args.runs, args.dict)
         f.start()
-
-
-if __name__ == '__main__':
-    PythonFuzz()

--- a/pythonfuzz/tracer.py
+++ b/pythonfuzz/tracer.py
@@ -1,11 +1,11 @@
 import collections
-import sys
 
 prev_line = 0
 prev_filename = ''
 data = collections.defaultdict(set)
 
-def trace(frame, event, arg):
+
+def trace(frame, event, _arg):
     if event != 'line':
         return trace
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-psutil==5.6.6
-functools32==3.2.3.post2; python_version < '3'
+psutil~=5.6

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open('requirements.txt') as f:
+    install_requires = [line.strip() for line in f]
+
 setuptools.setup(
     name="pythonfuzz",
     version="1.0.10",
@@ -10,10 +13,7 @@ setuptools.setup(
     description="Coverage-guided fuzz testing for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=[
-        # WARNING: Keep these values in line with those in requirements.txt
-        "psutil~=5.6"
-    ],
+    install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     name="pythonfuzz",
     version="1.0.10",
     author="GitLab B.V.",
+    maintainer="Marcell Perger",
     description="Coverage-guided fuzz testing for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -21,5 +22,5 @@ setuptools.setup(
         "Topic :: Software Development :: Testing"
     ],
     python_requires='>=3.5.3',
-    packages=setuptools.find_packages('.', exclude=("examples",))
+    packages=setuptools.find_packages('.', exclude=("examples", "tests"))
 )

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     install_requires=[
         # WARNING: Keep these values in line with those in requirements.txt
-        "psutil==5.6.3",
-        "functools32==3.2.3.post2; python_version < '3'",
+        "psutil~=5.6"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pythonfuzz
 
+
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
         def fuzz(buf):

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -15,5 +15,8 @@ def _fuzz(buf):
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
         with patch('logging.Logger.info') as mock:
-            pythonfuzz.fuzzer.Fuzzer(_fuzz).start()
+            try:
+                pythonfuzz.fuzzer.Fuzzer(_fuzz).start()
+            except SystemExit as e:
+                self.assertEqual(76, e.code)
             self.assertTrue(mock.called_once)

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -6,13 +6,14 @@ from unittest.mock import patch
 import pythonfuzz
 
 
+def _fuzz(buf):
+    f = io.BytesIO(buf)
+    z = zipfile.ZipFile(f)
+    z.testzip()
+
+
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
-        def fuzz(buf):
-            f = io.BytesIO(buf)
-            z = zipfile.ZipFile(f)
-            z.testzip()
-
         with patch('logging.Logger.info') as mock:
-            pythonfuzz.fuzzer.Fuzzer(fuzz).start()
+            pythonfuzz.fuzzer.Fuzzer(_fuzz).start()
             self.assertTrue(mock.called_once)

--- a/tests/test_nocrash.py
+++ b/tests/test_nocrash.py
@@ -1,15 +1,15 @@
 import unittest
-import zipfile
-import io
 from unittest.mock import patch
 
 import pythonfuzz
 
+
+def _fuzz(_buf):
+    return True
+
+
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
-        def fuzz(buf):
-            return True
-
         with patch('logging.Logger.info') as mock:
-            pythonfuzz.fuzzer.Fuzzer(fuzz, runs=100).start()
+            pythonfuzz.fuzzer.Fuzzer(_fuzz, runs=100).start()
             mock.assert_called_with('did %d runs, stopping now.', 100)

--- a/tests/test_nocrash.py
+++ b/tests/test_nocrash.py
@@ -11,5 +11,8 @@ def _fuzz(_buf):
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
         with patch('logging.Logger.info') as mock:
-            pythonfuzz.fuzzer.Fuzzer(_fuzz, runs=100).start()
+            try:
+                pythonfuzz.fuzzer.Fuzzer(_fuzz, runs=100).start()
+            except SystemExit as e:
+                self.assertEqual(0, e.code)
             mock.assert_called_with('did %d runs, stopping now.', 100)


### PR DESCRIPTION
- [x] Don't pin psutil version, fixes https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/pythonfuzz/-/issues/10
- [x] Make it work on Windows
- [x] Remove Python 2 compatibility code
- [x] Remove unused imports
- [x] Allow using `import pythonfuzz` to access `Fuzzer`
- [x] Fix divide-by-zero if code to fuzz is too fast
- [x] Use more accurate `time.perf_counter()` than `time.time()` ([`time.time()` might have a resolution of 1s on some platforms](https://docs.python.org/3.12/library/time.html#time.time))
- [x] Fix pickling errors in tests
- [x] Make tests test what the code actually does
- [x] Exclude tests from setup.py, fixes https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/pythonfuzz/-/issues/4
- [x] Don't use undocumented, private `random._randbelow` (use `random.randrange` instead)
- [x] Remove completely broken and no-way-it-works `__name__ == '__main__'` code